### PR TITLE
Detect the Travis host

### DIFF
--- a/src/main/java/nl/tudelft/ewi/sorcerers/TravisService.java
+++ b/src/main/java/nl/tudelft/ewi/sorcerers/TravisService.java
@@ -81,7 +81,7 @@ public class TravisService {
 	}
 
 	public InputStream getLogFromJobId(String host, String id) throws IOException {
-		AccessTokenHolder accessTokenHolder = authenticate();
+		AccessTokenHolder accessTokenHolder = authenticate(host);
 
 		Invocation logInvocation = this.client
 				.target("https://api.{host}/jobs/{jobId}/log.txt")
@@ -103,11 +103,12 @@ public class TravisService {
 		}
 	}
 
-	private AccessTokenHolder authenticate() throws IOException {
+	private AccessTokenHolder authenticate(String host) throws IOException {
 		String authRequest = String.format("{\"github_token\":\"%s\"}",
 				this.githubToken);
 		Invocation authInvocation = this.client
-				.target("https://api.travis-ci.com/auth/github")
+				.target("https://api.{host}/auth/github")
+				.resolveTemplate("host", host)
 				.request("application/vnd.travis-ci.2+json")
 				.header("User-Agent", "Octopull/1.0.0")
 				.buildPost(json(authRequest));

--- a/src/main/java/nl/tudelft/ewi/sorcerers/TravisService.java
+++ b/src/main/java/nl/tudelft/ewi/sorcerers/TravisService.java
@@ -80,11 +80,12 @@ public class TravisService {
 				.hostnameVerifier(hostnameVerifier).build();
 	}
 
-	public InputStream getLogFromJobId(String id) throws IOException {
+	public InputStream getLogFromJobId(String host, String id) throws IOException {
 		AccessTokenHolder accessTokenHolder = authenticate();
 
 		Invocation logInvocation = this.client
-				.target("https://api.travis-ci.com/jobs/{jobId}/log.txt")
+				.target("https://api.{host}/jobs/{jobId}/log.txt")
+				.resolveTemplate("host", host)
 				.resolveTemplate("jobId", id)
 				.queryParam("access_token", accessTokenHolder.access_token)
 				.request(MediaType.TEXT_PLAIN)
@@ -98,6 +99,7 @@ public class TravisService {
 			throw new RuntimeException(String.format(
 					"Failed to retrieve log from Travis CI, got status %d",
 					logResponse.getStatus()));
+			
 		}
 	}
 

--- a/src/main/java/nl/tudelft/ewi/sorcerers/TravisService.java
+++ b/src/main/java/nl/tudelft/ewi/sorcerers/TravisService.java
@@ -81,7 +81,14 @@ public class TravisService {
 	}
 
 	public InputStream getLogFromJobId(String host, String id) throws IOException {
-		AccessTokenHolder accessTokenHolder = authenticate(host);
+		// TODO proper handling of private repo access tokens
+		AccessTokenHolder accessTokenHolder;
+		if ("travis-ci.org".equals(host)) {
+			accessTokenHolder = new AccessTokenHolder();
+			accessTokenHolder.access_token = null;
+		} else {
+			accessTokenHolder = authenticate(host);
+		}
 
 		Invocation logInvocation = this.client
 				.target("https://api.{host}/jobs/{jobId}/log.txt")


### PR DESCRIPTION
Travis uses different hosts for the public service (`travis-ci.org`) and the commercial service (`travis-ci.com`). Accessing the wrong one causes no logs to be retrieved.
