### PR TITLE
Add constraint and checking for duplicate warnings

### DIFF
--- a/src/main/java/nl/tudelft/ewi/sorcerers/model/Warning.java
+++ b/src/main/java/nl/tudelft/ewi/sorcerers/model/Warning.java
@@ -5,9 +5,13 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @Entity
+@Table(uniqueConstraints=
+	@UniqueConstraint(columnNames = {"repo", "commit", "path", "line", "message"})) 
 @IdClass(WarningId.class)
 @XmlRootElement
 public class Warning {

--- a/src/main/java/nl/tudelft/ewi/sorcerers/model/WarningService.java
+++ b/src/main/java/nl/tudelft/ewi/sorcerers/model/WarningService.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.hibernate.exception.ConstraintViolationException;
+
 public class WarningService {
 	private WarningRepository warningRepository;
 
@@ -19,10 +21,15 @@ public class WarningService {
 	public Warning addWarningIfNew(String repo, String commit, String path, int line,
 			String message) {
 		Warning warning = this.warningRepository.find(repo, commit, path, line, message);
-		if (warning == null)
-			return this.warningRepository.add(new Warning(repo, commit, path, line, message));
-		else
+		if (warning == null) {
+			try {
+				return this.warningRepository.add(new Warning(repo, commit, path, line, message));
+			} catch(ConstraintViolationException e) {
+				return null;
+			}
+		} else {
 			return warning;
+		}
 	}
 
 	public Warning addWarningIfNew(Warning warning) {


### PR DESCRIPTION
In some cases (due to concurrency?) the checks for existing warnings were insufficient, and duplicate warnings were added to the database. Constraints were added to ensure this does not happen.
