### PR TITLE
Upgrade to Jetty 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
 	</build>
 	<properties>
 		<jersey.version>2.17</jersey.version>
-		<jetty.version>7.4.2.v20110526</jetty.version>
+		<jetty.version>9.3.4.RC0</jetty.version>
 		<hibernate.version>4.3.8.Final</hibernate.version>
 	</properties>
 </project>

--- a/src/main/java/nl/tudelft/ewi/sorcerers/Main.java
+++ b/src/main/java/nl/tudelft/ewi/sorcerers/Main.java
@@ -2,10 +2,15 @@ package nl.tudelft.ewi.sorcerers;
 
 import static org.glassfish.jersey.CommonProperties.METAINF_SERVICES_LOOKUP_DISABLE;
 
+import java.util.concurrent.ArrayBlockingQueue;
+
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.glassfish.jersey.servlet.ServletContainer;
 
 public class Main {
@@ -13,15 +18,23 @@ public class Main {
 	public static void main(String[] args) throws Exception {
 		System.out.println("Starting server on port 8080");
 
-		// Create the server
-		Server server = new Server(8080);
 		
+		// Create the server
+		ThreadPool threadPool = new QueuedThreadPool(10, 4, 60, new ArrayBlockingQueue<Runnable>(6000));
+		Server server = new Server(threadPool);
+
+		ServerConnector connector = new ServerConnector(server);
+		connector.setPort(8080);
+		server.addConnector(connector);
+
 		// Create a servlet context and add the jersey servlet
 		ServletContextHandler sch = new ServletContextHandler(server, "/");
 
 		FilterHolder servletContainer = new FilterHolder(ServletContainer.class);
-		servletContainer.setInitParameter("javax.ws.rs.Application", AppConfig.class.getCanonicalName());
-		servletContainer.setInitParameter(METAINF_SERVICES_LOOKUP_DISABLE, "true");
+		servletContainer.setInitParameter("javax.ws.rs.Application",
+				AppConfig.class.getCanonicalName());
+		servletContainer.setInitParameter(METAINF_SERVICES_LOOKUP_DISABLE,
+				"true");
 		sch.addFilter(servletContainer, "/*", null);
 
 		// Must add DefaultServlet for embedded Jetty.
@@ -30,7 +43,7 @@ public class Main {
 
 		// Start the server
 		server.start();
-		
+
 		// Wait for server to shutdown
 		server.join();
 	}


### PR DESCRIPTION
In order to prevent blocking of the server, use jetty 9 with a threadpool.
